### PR TITLE
feature(pivotal): Add links to pivotal stories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,9 +75,13 @@ export function prompter (cz, commit) {
 
     // Wrap these lines at 72 characters
     const body = wrap(answers.body, wrapOptions)
-    const pivotal = wrap('#' + answers.pivotal.trim().split(' ').join(' #'), wrapOptions)
+
+    const pivotalIDs = answers.pivotal.match(/[0-9]+/g)
+    const pivotal = pivotalIDs.map(function (id) {
+      return `#${id} (https://www.pivotaltracker.com/stories/show/${id})`
+    })
     const footer = wrap(answers.footer, wrapOptions)
 
-    commit(head + '\n\n' + body + '\n\n' + pivotal + '\n' + footer)
+    commit(head + '\n\n' + body + '\n\nPivotal ' + ((pivotalIDs.length === 1) ? 'Story' : 'Stories') + ':\n' + pivotal.join('\n') + '\n\n' + footer)
   })
 }


### PR DESCRIPTION
- Add links to pivotal stories
- Improve regex to account for existing '#' if given in the prompt

Each pivotal story is printed on one line. For example:

```
Pivotal Stories:
#116555500 (https://pivotaltracker.com/stories/show/116555500)
#116555000 (https://pivotaltracker.com/stories/show/116555000)
```

This is very handy because GitHub turns them into real links:

<img width="626" alt="screenshot 2016-04-01 16 16 54" src="https://cloud.githubusercontent.com/assets/338738/14218919/37e2b440-f825-11e5-83a0-659b0d911ab6.png">
